### PR TITLE
Test revisions for the newest deployer release

### DIFF
--- a/tests/remote-build-go/test.bats
+++ b/tests/remote-build-go/test.bats
@@ -7,10 +7,10 @@ teardown_file() {
 @test "deploy go projects with remote build" {
   run $DOCTL sbx deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'default' for remote building and deployment in runtime go:default"
-	assert_line -p "Submitted action 'explicit' for remote building and deployment in runtime go:1.15"
-#	assert_line -p "Submitted action 'dependencies-1.15' for remote building and deployment in runtime go:1.15"
-	assert_line -p "Submitted action 'dependencies-1.17' for remote building and deployment in runtime go:1.17"
+	assert_line -p "Submitted action 'test-remote-build-go/default' for remote building and deployment in runtime go:default"
+	assert_line -p "Submitted action 'test-remote-build-go/explicit' for remote building and deployment in runtime go:1.15"
+#	assert_line -p "Submitted action 'test-remote-build-go/dependencies-1.15' for remote building and deployment in runtime go:1.15"
+	assert_line -p "Submitted action 'test-remote-build-go/dependencies-1.17' for remote building and deployment in runtime go:1.17"
 }
 
 @test "invoke remotely built go lang actions" {

--- a/tests/remote-build-go1.15/test.bats
+++ b/tests/remote-build-go1.15/test.bats
@@ -7,7 +7,7 @@ teardown_file() {
 @test "deploy go projects with remote build" {
   run $DOCTL sbx deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'dependencies-1.15' for remote building and deployment in runtime go:1.15"
+	assert_line -p "Submitted action 'test-remote-build-go/dependencies-1.15' for remote building and deployment in runtime go:1.15"
 }
 
 @test "invoke remotely built go lang actions" {

--- a/tests/remote-build-nodejs/test.bats
+++ b/tests/remote-build-nodejs/test.bats
@@ -7,7 +7,7 @@ teardown_file() {
 @test "deploy nodejs projects with remote build" {
   run $DOCTL sbx deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'default' for remote building and deployment in runtime nodejs:default"
+	assert_line -p "Submitted action 'test-remote-build-nodejs/default' for remote building and deployment in runtime nodejs:default"
 }
 
 @test "invoke remotely built nodejs lang actions" {

--- a/tests/remote-build-php/test.bats
+++ b/tests/remote-build-php/test.bats
@@ -7,7 +7,7 @@ teardown_file() {
 @test "deploy php projects with remote build" {
   run $DOCTL sbx deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'default' for remote building and deployment in runtime php:default"
+	assert_line -p "Submitted action 'test-remote-build-php/default' for remote building and deployment in runtime php:default"
 }
 
 @test "invoke remotely built php lang actions" {

--- a/tests/remote-build-python/test.bats
+++ b/tests/remote-build-python/test.bats
@@ -7,7 +7,7 @@ teardown_file() {
 @test "deploy python projects with remote build" {
   run $DOCTL sbx deploy $BATS_TEST_DIRNAME --remote-build --verbose-build
 	assert_success
-	assert_line -p "Submitted action 'default' for remote building and deployment in runtime python:default"
+	assert_line -p "Submitted action 'test-remote-build-python/default' for remote building and deployment in runtime python:default"
 }
 
 @test "invoke remotely built python lang actions" {

--- a/tests/triggers/packages/test-triggers/hello/hello.js
+++ b/tests/triggers/packages/test-triggers/hello/hello.js
@@ -1,0 +1,7 @@
+function main(args) {
+    let name = args.name || 'stranger'
+    let greeting = 'Hello ' + name + '!'
+    console.log(greeting)
+    return {"body": greeting}
+  }
+  

--- a/tests/triggers/project.yml
+++ b/tests/triggers/project.yml
@@ -1,0 +1,24 @@
+environment: {}
+parameters: {}
+packages:
+  - name: test-triggers
+    environment: {}
+    parameters: {}
+    annotations: {}
+    functions:
+      - name: hello
+        binary: false
+        main: ''
+        runtime: 'nodejs:default'
+        web: true
+        parameters: {}
+        environment: {}
+        annotations: {}
+        limits: {}
+        triggers:
+          - name: sayit
+            sourceType: scheduler
+            sourceDetails:
+              cron: "* * * * *"
+              withBody:
+                name: tester

--- a/tests/triggers/test.bats
+++ b/tests/triggers/test.bats
@@ -1,0 +1,23 @@
+load ../test_setup.bash
+
+teardown_file() {
+	delete_package "test-triggers"
+}
+
+@test "deploy a project with valid trigger clause" {
+  run $DOCTL sls deploy $BATS_TEST_DIRNAME
+	assert_success
+}
+
+@test "ensure that the just-created trigger is actually present" {
+  run bash -c "$DOCTL sls trig get sayit | jq -r .triggerName"
+  assert_success
+  assert_output sayit
+}
+
+@test "ensure that undeploying a function with a trigger deletes its trigger also" {
+  run $DOCTL sls undeploy test-triggers/hello
+  assert_success
+  run bash -c "$DOCTL sls trig get sayit | jq -r .error.status"
+  assert_output -p 404
+}

--- a/tests/triggers/test.bats
+++ b/tests/triggers/test.bats
@@ -10,7 +10,7 @@ teardown_file() {
 }
 
 @test "ensure that the just-created trigger is actually present" {
-  run bash -c "$DOCTL sls trig get sayit | jq -r .triggerName"
+  run bash -c "$DOCTL sls trig get sayit | jq -r .name"
   assert_success
   assert_output sayit
 }

--- a/tests/unweb/test.bats
+++ b/tests/unweb/test.bats
@@ -28,6 +28,6 @@ teardown_file() {
     },'
 	assert_output --partial '{
       "key": "require-whisk-auth",
-      "value": true
+      "value": "xyzzy"
     },'
 }

--- a/tests/unweb/unweb-with-config/project.yml
+++ b/tests/unweb/unweb-with-config/project.yml
@@ -3,4 +3,4 @@ packages:
     actions:
       - name: notify
         web: false
-        webSecure: true
+        webSecure: xyzzy

--- a/tests/yaml_alias/project.yml
+++ b/tests/yaml_alias/project.yml
@@ -13,4 +13,4 @@ packages:
         name: gateway
       - <<: *default_action
         name: cli-gateway
-        webSecure: true
+        webSecure: xyzzy

--- a/tests/yaml_alias/test.bats
+++ b/tests/yaml_alias/test.bats
@@ -19,6 +19,6 @@ teardown_file() {
 	assert_success
 	assert_output --partial '{
       "key": "require-whisk-auth",
-      "value": true
+      "value": "xyzzy"
     },'
 }


### PR DESCRIPTION
This change covers some miscellaneous changes to track the latest deployer behavior.

Some changes simply adjust to changes in the deployer's output (fully qualified function names instead of simple ones).   

One new test covers triggers.   That test will actually fail when run against the current `feature/serverless` branch but should begin passing when PR digitalocean/doctl#1232 is merged.   The triggers test is somewhat lacking in coverage and will be improved in a subsequent update.