### PR TITLE
Add node 18.17.1 to the testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        go-version: [ 1.18.x ]
+        go-version: [ 1.21.x ]
         node-version: ['16.13.0', '18.17.1']
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       max-parallel: 1
       matrix:
         go-version: [ 1.18.x ]
+        node-version: ['16.13.0', '18.17.1']
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     concurrency: doctl_sandbox_tests
@@ -61,7 +62,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16.13.0'
+        node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies for bats testing
       run: npm install


### PR DESCRIPTION
This PR adds node 18.17.1 to the testing matrix. It also updates the Go version used to build doctl to 1.21.x as we've moved to that upstream https://github.com/digitalocean/doctl/pull/1410